### PR TITLE
Fix example environment file typos

### DIFF
--- a/docs/.env.development.example
+++ b/docs/.env.development.example
@@ -2,5 +2,5 @@
 APP_HOST=localhost
 APP_PORT=8080
 
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/councilwattch
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/councilwatch
 


### PR DESCRIPTION
Fix 2 typos in the example environment file.